### PR TITLE
Compiling issue with relative path name

### DIFF
--- a/lib/generators/ember_konacha/templates/spec_helper.js.coffee
+++ b/lib/generators/ember_konacha/templates/spec_helper.js.coffee
@@ -2,7 +2,7 @@
 #= require sinon
 
 # Load all testing support files
-#= require_tree support
+#= require_tree ./support
 
 #= require application
 


### PR DESCRIPTION
I had an issue with "rake db:run" that begins:
ActionView::Template::Error: require_tree argument must be a relative path
  (in /home/max/Code/potlucky/spec/javascripts/spec_helper.js.coffee:5)
This change resolved that issue for me. Thanks for the great project!
